### PR TITLE
Update xpath, links and fix CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 
 name: Release
 on:
+  workflow_dispatch:
   schedule:
     - cron: "5 */12 * * *"
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,10 @@ jobs:
         sudo apt install -y libxml2-utils
         mkdir thunderbird
         cd thunderbird
-        wget https://www.thunderbird.net/en-US/ -O index.html
+        wget https://www.thunderbird.net/en-US/about -O index.html
         echo "Downloading"
         
-        wget $(xmllint --html index.html --xpath '/html/body/nav/div/div/div/div/div[1]/div/ul/li[4]/a' 2>/dev/null | grep -E -o 'href="(.*" )' | cut -d " " -f1 | grep -E -o '"(.*)"' | sed 's/\&amp;/\&/g' | tail -n 1 | sed 's,",,g') -O thunderbird.tar.bz2
+        wget $(xmllint --html index.html --xpath '/html/body/main/section[4]/section/article[2]/section[1]/main/aside/div/ul/li[4]/a' 2>/dev/null | grep -Po 'href="\K[^"]*' | sed 's|\&amp;|\&|g')' -O thunderbird.tar.bz2
         tar -xf thunderbird.tar.bz2
         cd ..
 
@@ -72,8 +72,8 @@ jobs:
         sudo apt -y install libxml2-utils
         mkdir thunderbird
         cd thunderbird
-        wget https://www.thunderbird.net/en-US/download/beta -O index.html
-        wget $(xmllint --html index.html --xpath '/html/body/main/div/div/div[1]/div/ul/li[4]/a' 2>/dev/null | grep -E -o 'href="(.*" )' | cut -d " " -f1 | grep -E -o '"(.*)"' | sed 's/\&amp;/\&/g' | tail -n 1 | sed 's,",,g') -O thunderbird.tar.bz2
+        wget https://www.thunderbird.net/en-US/download/about -O index.html
+        wget $(xmllint --html index.html --xpath '/html/body/main/section[4]/section/article[2]/section[2]/main/aside/div/ul/li[4]/a' 2>/dev/null | grep -Po 'href="\K[^"]*' | sed 's|\&amp;|\&|g') -O thunderbird.tar.bz2
         tar -xf thunderbird.tar.bz2
         cd ..
 
@@ -119,8 +119,8 @@ jobs:
         sudo apt -y install libxml2-utils
         mkdir thunderbird
         cd thunderbird
-        wget https://www.thunderbird.net/en-US/ -O index.html 
-        wget $(xmllint --html index.html --xpath '/html/body/main/section[5]/section/article[2]/section[3]/main/aside/div/ul/li[4]/a' 2>/dev/null | grep -E -o 'href="(.*" )' | cut -d " " -f1 | grep -E -o '"(.*)"' | sed 's/\&amp;/\&/g' | tail -n 1 | sed 's,",,g') -O thunderbird.tar.bz2
+        wget https://www.thunderbird.net/en-US/about -O index.html 
+        wget $(xmllint --html index.html --xpath '/html/body/main/section[4]/section/article[2]/section[3]/main/aside/div/ul/li[4]/a' 2>/dev/null | grep -Po 'href="\K[^"]*' | sed 's|\&amp;|\&|g') -O thunderbird.tar.bz2
         tar -xf thunderbird.tar.bz2
         cd ..
 
@@ -205,6 +205,7 @@ jobs:
     - uses: actions/download-artifact@v2.1.1
       with:
         name: thunderbird-nightly-continuous-x86_64.AppImage
+        path: thunderbird-nightly-continuous-x86_64.AppImage
 
     - name: Release
       uses: marvinpinto/action-automatic-releases@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   Thunderbird:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         version: ['3.8']

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         wget https://www.thunderbird.net/en-US/about -O index.html
         echo "Downloading"
         
-        wget $(xmllint --html index.html --xpath '/html/body/main/section[4]/section/article[2]/section[1]/main/aside/div/ul/li[4]/a' 2>/dev/null | grep -Po 'href="\K[^"]*' | sed 's|\&amp;|\&|g')' -O thunderbird.tar.bz2
+        wget $(xmllint --html index.html --xpath '/html/body/main/section[4]/section/article[2]/section[1]/main/aside/div/ul/li[4]/a' 2>/dev/null | grep -Po 'href="\K[^"]*' | sed 's|\&amp;|\&|g') -O thunderbird.tar.bz2
         tar -xf thunderbird.tar.bz2
         cd ..
 
@@ -72,7 +72,7 @@ jobs:
         sudo apt -y install libxml2-utils
         mkdir thunderbird
         cd thunderbird
-        wget https://www.thunderbird.net/en-US/download/about -O index.html
+        wget https://www.thunderbird.net/en-US/about -O index.html
         wget $(xmllint --html index.html --xpath '/html/body/main/section[4]/section/article[2]/section[2]/main/aside/div/ul/li[4]/a' 2>/dev/null | grep -Po 'href="\K[^"]*' | sed 's|\&amp;|\&|g') -O thunderbird.tar.bz2
         tar -xf thunderbird.tar.bz2
         cd ..

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         version: ['3.8']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.5.3
 
     - name: Download Thunderbird
       run: |
@@ -54,18 +54,18 @@ jobs:
        
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v3.1.2
       with:
         name: thunderbird-continuous-x86_64.AppImage
         path: 'thunderbird/dist'
 
   Thunderbird-Beta:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         version: ['3.8']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.5.3
 
     - name: Download Thunderbird Beta
       run: |
@@ -101,18 +101,18 @@ jobs:
        
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v3.1.2
       with:
         name: thunderbird-beta-continuous-x86_64.AppImage
         path: 'thunderbird/dist'
 
   Thunderbird-Nightly:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         version: ['3.8']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.5.3
 
     - name: Download Thunderbird Nightly
       run: |
@@ -148,7 +148,7 @@ jobs:
        
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v3.1.2
       with:
         name: thunderbird-nightly-continuous-x86_64.AppImage
         path: 'thunderbird/dist'
@@ -160,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2.1.1
       with:
         name: thunderbird-continuous-x86_64.AppImage
 
@@ -180,7 +180,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2.1.1
       with:
         name: thunderbird-beta-continuous-x86_64.AppImage
 
@@ -200,7 +200,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2.1.1
       with:
         name: thunderbird-nightly-continuous-x86_64.AppImage
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,7 @@ jobs:
     - uses: actions/download-artifact@v2.1.1
       with:
         name: thunderbird-continuous-x86_64.AppImage
+        path: thunderbird-continuous-x86_64.AppImage
 
     - name: Release
       uses: marvinpinto/action-automatic-releases@latest
@@ -183,6 +184,7 @@ jobs:
     - uses: actions/download-artifact@v2.1.1
       with:
         name: thunderbird-beta-continuous-x86_64.AppImage
+        path: thunderbird-beta-continuous-x86_64.AppImage
 
     - name: Release
       uses: marvinpinto/action-automatic-releases@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         wget https://www.thunderbird.net/en-US/ -O index.html
         echo "Downloading"
         
-        wget $(xmllint --html index.html --xpath '/html/body/header/section[2]/div/div/ul/li[4]/a' 2>/dev/null | grep -E -o 'href="(.*" )' | cut -d " " -f1 | grep -E -o '"(.*)"' | sed 's/\&amp;/\&/g' | tail -n 1 | sed 's,",,g') -O thunderbird.tar.bz2
+        wget $(xmllint --html index.html --xpath '/html/body/nav/div/div/div/div/div[1]/div/ul/li[4]/a' 2>/dev/null | grep -E -o 'href="(.*" )' | cut -d " " -f1 | grep -E -o '"(.*)"' | sed 's/\&amp;/\&/g' | tail -n 1 | sed 's,",,g') -O thunderbird.tar.bz2
         tar -xf thunderbird.tar.bz2
         cd ..
 
@@ -72,8 +72,8 @@ jobs:
         sudo apt -y install libxml2-utils
         mkdir thunderbird
         cd thunderbird
-        wget https://www.thunderbird.net/en-US/ -O index.html
-        wget $(xmllint --html index.html --xpath '/html/body/main/section[5]/section/article[2]/section[2]/main/aside/div/ul/li[4]/a' 2>/dev/null | grep -E -o 'href="(.*" )' | cut -d " " -f1 | grep -E -o '"(.*)"' | sed 's/\&amp;/\&/g' | tail -n 1 | sed 's,",,g') -O thunderbird.tar.bz2
+        wget https://www.thunderbird.net/en-US/download/beta -O index.html
+        wget $(xmllint --html index.html --xpath '/html/body/main/div/div/div[1]/div/ul/li[4]/a' 2>/dev/null | grep -E -o 'href="(.*" )' | cut -d " " -f1 | grep -E -o '"(.*)"' | sed 's/\&amp;/\&/g' | tail -n 1 | sed 's,",,g') -O thunderbird.tar.bz2
         tar -xf thunderbird.tar.bz2
         cd ..
 


### PR DESCRIPTION
closes #11
- Updated xpath in the release workflow for Stable, Beta and Nightly ~~(can't find download link for nightly version on official site)~~.
- Changed runner to Ubuntu 20.04, because 18.04 is deprecated.
- Updated all actions to latest versions.
- Replaced link extraction with shorter regex

You can see and test working appimages in [releases](https://github.com/Archargelod/Thunderbird-AppImage/releases)
